### PR TITLE
ref: focus-visible

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "files.exclude": {
-        "**/dist": true,
+        "**/dist": false,
         "**/node_modules": true
     },
     "editor.formatOnSave": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@sagemodeninja/fluent-command-bar-component",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@sagemodeninja/fluent-command-bar-component",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.5.1",
@@ -3164,9 +3164,9 @@
             "dev": true
         },
         "node_modules/schema-utils": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
-            "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+            "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
             "dev": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
@@ -3246,9 +3246,9 @@
             "dev": true
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "dependencies": {
                 "randombytes": "^2.1.0"
@@ -6627,9 +6627,9 @@
             "dev": true
         },
         "schema-utils": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
-            "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+            "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
@@ -6692,9 +6692,9 @@
             }
         },
         "serialize-javascript": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "requires": {
                 "randombytes": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sagemodeninja/fluent-command-bar-component",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "Web component implementation of Windows 11's Command Bar.",
     "main": "dist/fluent-command-bar-component.js",
     "types": "src/@types/fluent-command-bar-component.d.ts",

--- a/src/fluent-app-bar-button.ts
+++ b/src/fluent-app-bar-button.ts
@@ -39,9 +39,8 @@ export class FluentAppBarButton extends CustomComponent {
             position: relative;
         }
         
-        :host(:focus) .control {
-            background-color: var(--fill-subtle-secondary);
-            box-shadow: 0 0 0 1.5px var(--fill-accent-secondary);
+        :host(:focus-visible) .control {
+            outline: var(--fill-accent-secondary) solid 2px;
         }
 
         @media (hover: hover) {
@@ -202,6 +201,11 @@ export class FluentAppBarButton extends CustomComponent {
             .replace('escape', 'esc')
     }
 
+    constructor() {
+        super()
+        this.setAccessibilityRoles()
+    }
+
     public render() {
         return `
             <div class="control" part="control">
@@ -214,13 +218,14 @@ export class FluentAppBarButton extends CustomComponent {
         `
     }
 
-    connectedCallback() {
+    public connectedCallback() {
         this.setState()
         this.addEventListeners()
     }
 
     protected stateHasChanged() {
         this.setState()
+        this.setAccessibilityRoles()
     }
     
     private setState() {
@@ -231,8 +236,16 @@ export class FluentAppBarButton extends CustomComponent {
         this.setTitle()
     }
 
+    private setAccessibilityRoles() {
+        const disabled = this.disabled ?? false
+
+        this.setAttribute('role', 'button')
+        this.setAttribute('role-label', this.label ?? this.command)
+        this.setAttribute('role-disabled', disabled.toString())
+    }
+
     private addEventListeners() {
-        this.addEventListener('click', () => this.onInvoke(false))
+        this.addEventListener('click', this.onInvoke.bind(this))
         this.addEventListener('keypress', ({code}) => {
             if (code === 'Enter') this.onAltInvoke()
         })
@@ -262,8 +275,7 @@ export class FluentAppBarButton extends CustomComponent {
         this.title = [this.label, accelerator].filter(Boolean).join(' ')
     }
 
-    private onInvoke(keyboard: boolean) {
-        if (!keyboard) this.blur()
+    private onInvoke() {
         this.dispatchEvent(new CustomEvent('invoke'))
     }
 
@@ -275,7 +287,7 @@ export class FluentAppBarButton extends CustomComponent {
         this.classList.add('invoked')
         defer(() => this.classList.remove('invoked'), 200)
 
-        this.onInvoke(true)
+        this.onInvoke()
     }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,9 +23,9 @@ module.exports = (_, argv) => {
             rules: [
                 isDev
                     ? {
-                          test: /\.css$/i,
-                          use: [MiniCssExtractPlugin.loader, 'css-loader'],
-                      }
+                        test: /\.css$/i,
+                        use: [MiniCssExtractPlugin.loader, 'css-loader'],
+                    }
                     : {},
                 {
                     test: /\.ts$/,
@@ -39,13 +39,13 @@ module.exports = (_, argv) => {
         },
         devServer: isDev
             ? {
-                  static: {
-                      directory: path.join(__dirname, 'dist'),
-                  },
-                  compress: true,
-                  https: false,
-                  port: 3000,
-              }
+                static: {
+                    directory: path.join(__dirname, 'dist'),
+                },
+                compress: true,
+                https: false,
+                port: 3000,
+            }
             : {},
         devtool: isDev ? 'inline-source-map' : 'source-map',
     }


### PR DESCRIPTION
## Fixes

+ Use `outline` to highlight focused element instead of `box-shadow`.
+ Use`:focus-visible` for highlighting to distinguish between keyboard and mouse focus.
+ Fixed an issue with highlight rendering in Safari and Mozilla Firefox.

## Changes

+ Improve dismiss menu feature.
+ Initial accessibility features.